### PR TITLE
Add Email Grab

### DIFF
--- a/src/components/EmailGrab.tsx
+++ b/src/components/EmailGrab.tsx
@@ -1,0 +1,33 @@
+const EmailGrab = () => (
+  <section className="bg-gradient-to-b from-black to-purple-900/10">
+    <div
+      style={{
+        position: "relative",
+        overflow: "hidden",
+        width: "50vw",
+        paddingTop: "31vw",
+        marginLeft: "auto",
+        marginRight: "auto",
+      }}
+    >
+      <iframe
+        src="https://bd3da8ba.sibforms.com/serve/MUIFAAW-uH2vmKuOmYwf90G6ALEmuhaLjgPm13jqngfGuhYHz7k279087I6DVhK1W_sFcmnDjw97AyPCsqmMG9-nWTXM4-9US_K3bgySx_JnZksqCDK217cDtQ6MG-IC9gNIipKu9MMWR6ZH0KDMHVtaDXbQ3mMdeelHNLTLWoMaVE48go8g4gqT9fcxRCI6aNylWG-9cUkvNTIr"
+        style={{
+          display: "block",
+          marginLeft: "auto",
+          marginRight: "auto",
+          maxWidth: "100%",
+          position: "absolute",
+          top: 0,
+          left: 0,
+          bottom: 0,
+          right: 0,
+          width: " 100%",
+          height: "100%",
+        }}
+      ></iframe>
+    </div>
+  </section>
+);
+
+export default EmailGrab;

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -6,6 +6,7 @@ import Sponsors from "../components/Sponsors";
 import Venue from "../components/Venue";
 import CodeOfConduct from "../components/CodeOfConduct";
 import Footer from "../components/Footer";
+import EmailGrab from "@/components/EmailGrab";
 
 const Index = () => {
   return (
@@ -15,6 +16,7 @@ const Index = () => {
       <Speakers />
       <Sponsors />
       <Venue />
+      <EmailGrab />
       <CodeOfConduct />
       <Footer />
     </div>


### PR DESCRIPTION
Create a Brevo email grab component and add it to the homepage

<img width="1356" height="853" alt="image" src="https://github.com/user-attachments/assets/a71c912a-d4f1-42eb-b1f7-c548a8ed207e" />


Currently I have it between the venue and code of conduct settings, but it's easy to move.